### PR TITLE
Scaffold Pico SDK C++ project with keypad-to-LED firmware and documentation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,19 @@
+cmake_minimum_required(VERSION 3.13)
+
+include(pico_sdk_import.cmake)
+
+project(pico_keypad_led C CXX ASM)
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_CXX_STANDARD 17)
+
+pico_sdk_init()
+
+add_executable(pico_keypad_led
+  src/main.cpp
+)
+
+target_include_directories(pico_keypad_led PRIVATE include)
+
+target_link_libraries(pico_keypad_led pico_stdlib)
+
+pico_add_extra_outputs(pico_keypad_led)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,46 @@
+# Pico W Keypad-to-LED Controller
+
+A Raspberry Pi Pico W C++ firmware project that reads a 4x4 membrane keypad and drives 12 LEDs.
+
+## Features
+- 4x4 keypad scanning on 8 GPIO pins
+- 12 independent LED outputs
+- Key actions map directly to LED groups:
+  - `1..8`: turn on LED 1..8
+  - `9`: turn on LED 1..8 together
+  - `0`: turn off LED 1..8 together
+  - `A..D`: turn on LED 9..12
+  - `*`: turn on LED 9..12 together
+  - `#`: turn off LED 9..12 together
+
+## Repository Layout
+- `src/main.cpp`: Firmware entry point and keypad/LED control logic
+- `include/`: Reserved for headers if the firmware grows
+- `docs/wiring.md`: Components and pin mapping from Wokwi diagram
+- `docs/architecture.md`: Module and behavior documentation
+- `CMakeLists.txt`: Pico SDK build file
+
+## Hardware
+See `docs/wiring.md` for full details.
+
+## Build and Flash (Real Pico W)
+1. Install Pico SDK toolchain.
+2. Set `PICO_SDK_PATH`.
+3. Build:
+   ```bash
+   mkdir -p build
+   cd build
+   cmake ..
+   make -j
+   ```
+4. Hold **BOOTSEL** while connecting Pico W via USB.
+5. Copy generated `pico_keypad_led.uf2` to `RPI-RP2` mass storage.
+
+## Run in Wokwi
+1. Create a new **Raspberry Pi Pico** C++ project in Wokwi.
+2. Replace `diagram.json` with the provided diagram.
+3. Replace source with `src/main.cpp` contents.
+4. Start simulation and press keypad buttons.
+
+## Wi-Fi Note
+This firmware does not use Wi-Fi. No credentials are required.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,32 @@
+# Firmware Architecture
+
+## Overview
+The firmware is intentionally minimal and preserves the original behavior: a polling loop reads keypad input and updates LEDs.
+
+## `src/main.cpp`
+
+### Static configuration
+- `keys[4][4]`: keypad character map.
+- `ledPins[12]`: GPIO order used by action logic.
+- `rowPins[4]`, `colPins[4]`: keypad matrix GPIO assignment.
+
+### Initialization (`init_gpio`)
+- Configures all LED pins as outputs and sets them LOW.
+- Configures row pins as inputs with pull-up.
+- Configures column pins as outputs and idles them HIGH.
+
+### Key scanning (`get_key`)
+- Drives one column LOW at a time.
+- Reads rows for active-low press detection.
+- Uses simple key-release wait debounce.
+- Returns pressed key or `\0` when no key is pressed.
+
+### Main loop
+- Polls `get_key()`.
+- Executes a `switch` with the same key-to-LED behavior as the provided source.
+- Sleeps 10ms per cycle.
+
+## Behavior Guarantees
+- No Wi-Fi use.
+- No dynamic allocation.
+- Deterministic polling-based control flow.

--- a/docs/wiring.md
+++ b/docs/wiring.md
@@ -1,0 +1,49 @@
+# Wiring and GPIO Mapping
+
+## Components List (from `diagram.json`)
+- 1x Raspberry Pi Pico / Pico W board
+- 1x 4x4 membrane keypad
+- 12x LEDs (8 blue, 4 red)
+- 12x 220Ω resistors (LED current limiting)
+- 4x 1kΩ resistors (keypad row pull-ups to 3V3)
+- Jumper wires / breadboard interconnects
+
+## Keypad Wiring
+### Columns
+| Keypad pin | Pico GPIO |
+|---|---|
+| C1 | GP19 |
+| C2 | GP18 |
+| C3 | GP17 |
+| C4 | GP16 |
+
+### Rows
+| Keypad pin | Pico GPIO | Extra resistor |
+|---|---|---|
+| R1 | GP26 | 1kΩ pull-up to 3V3 |
+| R2 | GP22 | 1kΩ pull-up to 3V3 |
+| R3 | GP21 | 1kΩ pull-up to 3V3 |
+| R4 | GP20 | 1kΩ pull-up to 3V3 |
+
+## LED Wiring
+All LED cathodes connect to GND. Each LED anode is connected to its GPIO through a 220Ω resistor.
+
+| Logical LED | Label | Pico GPIO |
+|---|---|---|
+| LED1 | 1 | GP11 |
+| LED2 | 2 | GP10 |
+| LED3 | 3 | GP9 |
+| LED4 | 4 | GP8 |
+| LED5 | 5 | GP7 |
+| LED6 | 6 | GP6 |
+| LED7 | 7 | GP5 |
+| LED8 | 8 | GP4 |
+| LED9 | A | GP3 |
+| LED10 | B | GP2 |
+| LED11 | C | GP28 |
+| LED12 | D | GP27 |
+
+## Assumptions and Notes
+- The provided firmware treats row inputs as active-low during scan.
+- External 1kΩ row pull-ups from the diagram are retained; internal pull-ups are also enabled in firmware for robustness.
+- Pin mapping follows the source arrays exactly to preserve behavior.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,0 +1,97 @@
+#include <array>
+#include "pico/stdlib.h"
+
+constexpr uint8_t LEDS = 12;
+constexpr uint8_t ROWS = 4;
+constexpr uint8_t COLS = 4;
+
+const char keys[ROWS][COLS] = {
+    {'1', '2', '3', 'A'},
+    {'4', '5', '6', 'B'},
+    {'7', '8', '9', 'C'},
+    {'*', '0', '#', 'D'}
+};
+
+// Pins connected to LED1, LED2, LED3, ...LED12
+const std::array<uint, LEDS> ledPins = {11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 28, 27};
+const std::array<uint, ROWS> rowPins = {26, 22, 21, 20}; // Pins connected to R1, R2, R3, R4
+const std::array<uint, COLS> colPins = {19, 18, 17, 16}; // Pins connected to C1, C2, C3, C4
+
+static void init_gpio() {
+  for (uint8_t l = 0; l < LEDS; l++) {
+    gpio_init(ledPins[l]);
+    gpio_set_dir(ledPins[l], GPIO_OUT);
+    gpio_put(ledPins[l], 0);
+  }
+
+  for (uint8_t r = 0; r < ROWS; r++) {
+    gpio_init(rowPins[r]);
+    gpio_set_dir(rowPins[r], GPIO_IN);
+    gpio_pull_up(rowPins[r]);
+  }
+
+  for (uint8_t c = 0; c < COLS; c++) {
+    gpio_init(colPins[c]);
+    gpio_set_dir(colPins[c], GPIO_OUT);
+    gpio_put(colPins[c], 1);
+  }
+}
+
+static char get_key() {
+  for (uint8_t c = 0; c < COLS; c++) {
+    for (uint8_t i = 0; i < COLS; i++) gpio_put(colPins[i], 1);
+    gpio_put(colPins[c], 0);
+    sleep_us(5);
+
+    for (uint8_t r = 0; r < ROWS; r++) {
+      if (!gpio_get(rowPins[r])) {
+        while (!gpio_get(rowPins[r])) {
+          sleep_ms(1);
+        }
+        return keys[r][c];
+      }
+    }
+  }
+
+  return '\0';
+}
+
+int main() {
+  stdio_init_all();
+  init_gpio();
+
+  while (true) {
+    char key = get_key();
+
+    if (key != '\0') {
+      switch (key) {
+        case '1': gpio_put(ledPins[0], 1); break;
+        case '2': gpio_put(ledPins[1], 1); break;
+        case '3': gpio_put(ledPins[2], 1); break;
+        case '4': gpio_put(ledPins[3], 1); break;
+        case '5': gpio_put(ledPins[4], 1); break;
+        case '6': gpio_put(ledPins[5], 1); break;
+        case '7': gpio_put(ledPins[6], 1); break;
+        case '8': gpio_put(ledPins[7], 1); break;
+        case '9':
+          for (uint8_t l = 0; l < 8; l++) gpio_put(ledPins[l], 1);
+          break;
+        case '0':
+          for (uint8_t l = 0; l < 8; l++) gpio_put(ledPins[l], 0);
+          break;
+        case 'A': gpio_put(ledPins[8], 1); break;
+        case 'B': gpio_put(ledPins[9], 1); break;
+        case 'C': gpio_put(ledPins[10], 1); break;
+        case 'D': gpio_put(ledPins[11], 1); break;
+        case '*':
+          for (uint8_t l = 8; l < 12; l++) gpio_put(ledPins[l], 1);
+          break;
+        case '#':
+          for (uint8_t l = 8; l < 12; l++) gpio_put(ledPins[l], 0);
+          break;
+      }
+    }
+
+    sleep_ms(10);
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide a clean Pico SDK C/C++ repository layout and documentation for a Raspberry Pi Pico W project that reads a 4x4 keypad and drives 12 LEDs. 
- Preserve the original keypad-to-LED control logic and GPIO mapping while making the code runnable under the Pico SDK runtime. 
- Supply clear wiring, architecture, and usage documentation so the project can be simulated in Wokwi and built/flashed to real hardware. 

### Description
- Added a Pico SDK build entrypoint `CMakeLists.txt` and created a C++ firmware entry in `src/main.cpp` that preserves the original key-to-LED behavior and pin mappings. 
- Implemented GPIO initialization, a column-driven keypad scan with simple debounce, and the exact key->LED switch actions in `src/main.cpp`. 
- Added documentation files: `README.md` (overview, build/flash, Wokwi instructions, Wi‑Fi note), `docs/wiring.md` (components list and full GPIO pin mapping), and `docs/architecture.md` (code structure and runtime behavior). 
- Reserved `include/` for future headers and kept all behavioral logic unchanged from the provided source (pin order and actions preserved). 

### Testing
- Verified that the new files exist and inspected their contents with `nl -ba src/main.cpp`, `nl -ba README.md`, `nl -ba docs/wiring.md`, `nl -ba docs/architecture.md`, and `nl -ba CMakeLists.txt`, all showing the expected content. 
- Performed basic repository verification steps to ensure the scaffold and docs were created successfully. 
- No automated build or unit tests were run in this PR; to build locally use `mkdir build && cd build && cmake .. && make -j` to compile and produce the UF2 for flashing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f29230af28832fa1340bbf90d98765)